### PR TITLE
Fixed filesize(): stat failed for

### DIFF
--- a/classes/Kohana/ProfilerToolbar.php
+++ b/classes/Kohana/ProfilerToolbar.php
@@ -251,7 +251,7 @@ class Kohana_ProfilerToolbar {
     $files = get_included_files();
     $res   = array('data' => array(), 'total' => array('size' => 0, 'lines' => 0, 'count' => 0));
 
-    foreach ($files as $file) {
+    foreach ($files as $file) if(file_exists($file)){
       $size  = filesize($file);
       $lines = substr_count(file_get_contents($file), "\n");
       $res['total']['size'] += $size;


### PR DESCRIPTION
I had 
ErrorException [ 2 ]: filesize(): stat failed for APPPATH/cache/mustache/__Mustache_1bc89ca19b4c5cb46468b88dd9b6807d.php ~ MODPATH/profilertoolbar/classes/Kohana/ProfilerToolbar.php [ 255 ]
and fixed it by adding if(file_exists($file))
